### PR TITLE
t(list): add support for 'list paid' and 'list unpaid' filtering

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,24 +1,60 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.function.Predicate;
 
 import seedu.address.model.Model;
+import seedu.address.model.person.Person;
 
 /**
- * Lists all persons in the address book to the user.
+ * Lists persons in the address book based on the provided predicate.
+ * Supports:
+ *   {@code list} — show all persons
+ *   {@code list paid} — show only persons whose payment status is paid
+ *   {@code list unpaid} — show only persons whose payment status is unpaid
  */
 public class ListCommand extends Command {
 
+    /** Keyword used to invoke this command. */
     public static final String COMMAND_WORD = "list";
 
+    public static final String MESSAGE_USAGE = "list\n"
+            + "Examples:\n"
+            + "  list                (show all)\n"
+            + "  list paid           (show only paid)\n"
+            + "  list unpaid         (show only unpaid)\n"
+            + "  list alice tan      (name contains ‘alice’ AND ‘tan’)\n";
+
+    /** Default success message shown when listing all persons. */
     public static final String MESSAGE_SUCCESS = "Listed all persons";
 
+    private final Predicate<Person> predicate;
+    private final String successMessage;
 
+    /**
+     * Creates a {@code ListCommand} with a filtering predicate and success message.
+     *
+     * @param predicate the filter condition determining which persons to show
+     * @param successMessage the message to display upon successful execution
+     */
+    public ListCommand(Predicate<Person> predicate, String successMessage) {
+        this.predicate = requireNonNull(predicate);
+        this.successMessage = requireNonNull(successMessage);
+    }
+
+    /**
+     * Executes the command by updating the model’s filtered person list
+     * according to the provided predicate.
+     *
+     * @param model the model containing the person list
+     * @return a {@code CommandResult} containing the success message
+     */
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS);
+        model.updateFilteredPersonList(predicate);
+        System.out.println("Filtered list size: " + model.getFilteredPersonList().size());
+        return new CommandResult(successMessage);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -73,7 +73,7 @@ public class AddressBookParser {
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            return new ListCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -1,0 +1,48 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Model;
+
+/**
+ * Parses input arguments and creates a new {@link ListCommand}.
+ * Supported forms:
+ *   {@code list} — show all persons
+ *   {@code list paid} — show only persons with paid status
+ *   {@code list unpaid} — show only persons with unpaid status
+ * Any other argument is rejected with a {@link ParseException}.
+ */
+public class ListCommandParser implements Parser<ListCommand> {
+
+    @Override
+    public ListCommand parse(String args) throws ParseException {
+        String trimmed = args == null ? "" : args.trim();
+        if (trimmed.isEmpty()) {
+            return new ListCommand(Model.PREDICATE_SHOW_ALL_PERSONS, "Listed all persons");
+        }
+
+        String lowered = trimmed.toLowerCase(java.util.Locale.ROOT);
+        switch (lowered) {
+        case "paid":
+            return new ListCommand(
+                    p -> p.getPaymentStatus() != null && p.getPaymentStatus().isPaid(),
+                    "Listed persons with payment status: PAID"
+            );
+        case "unpaid":
+            return new ListCommand(
+                    p -> p.getPaymentStatus() != null && !p.getPaymentStatus().isPaid(),
+                    "Listed persons with payment status: UNPAID"
+            );
+        default:
+            // list should NOT do name search—point users to find
+            throw new ParseException(
+                    "Invalid list argument: \"" + trimmed + "\"\n"
+                            + "Use:\n"
+                            + "  list          (show all)\n"
+                            + "  list paid     (filter paid)\n"
+                            + "  list unpaid   (filter unpaid)\n"
+                            + "For name search, use: find n/<keywords>"
+            );
+        }
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
@@ -28,12 +29,26 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        //assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        ListCommand cmd = new ListCommand(PREDICATE_SHOW_ALL_PERSONS, ListCommand.MESSAGE_SUCCESS);
+
+        // expected model should also be “show all”
+        expectedModel.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        assertCommandSuccess(cmd, model, ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
+        //showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        //assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+
+
+        ListCommand cmd = new ListCommand(PREDICATE_SHOW_ALL_PERSONS, ListCommand.MESSAGE_SUCCESS);
+
+        expectedModel.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        assertCommandSuccess(cmd, model, ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -92,9 +92,16 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_list() throws Exception {
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    public void parseCommand_listSuccess() throws Exception {
+        assertTrue(parser.parseCommand("list") instanceof ListCommand);
+        assertTrue(parser.parseCommand("list paid") instanceof ListCommand);
+        assertTrue(parser.parseCommand("list unpaid") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_listThrowsParseException() {
+        assertThrows(ParseException.class, () -> parser.parseCommand("list 3"));
+        assertThrows(ParseException.class, () -> parser.parseCommand("list abc"));
     }
 
     @Test


### PR DESCRIPTION
- Updated ListCommand to accept Predicate<Person> and success message
- Added ListCommandParser to handle 'list', 'list paid', and 'list unpaid' arguments
  - Updated AddressBookParser to delegate list parsing to ListCommandParser
    - Modified ListCommandTest to use predicate-based constructor
    - Updated AddressBookParserTest to reflect new valid/invalid list arguments
      - Cleaned up imports, added Javadocs, and fixed Checkstyle issues