### PR TITLE
fix(parent): show error when adding cost to parent

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -61,6 +61,8 @@ public class AddCommand extends Command {
             "New person with cost information added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON =
             "This person already exists in the address book.";
+    public static final String MESSAGE_PARENT_COST_IMMUTABLE =
+            "Cannot add cost for a parent. Parent cost is derived from their linked children.";
 
     private final Person toAdd;
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -91,6 +91,9 @@ public class AddCommandParser implements Parser<AddCommand> {
         } else if (type.isParent() && argMultimap.getValue(PREFIX_SCHEDULE).isPresent()) {
             throw new ParseException("Parents cannot have a schedule.");
         }
+        if (type.isParent() && argMultimap.getValue(PREFIX_PAY).isPresent()) {
+            throw new ParseException(AddCommand.MESSAGE_PARENT_COST_IMMUTABLE);
+        }
         Cost cost = argMultimap.getValue(PREFIX_PAY).isPresent()
                 ? ParserUtil.parseCost(argMultimap.getValue(PREFIX_PAY).get())
                 : null;

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -221,6 +221,15 @@ public class AddCommandParserTest {
                 + ADDRESS_DESC_BOB
                 + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
 
+        // cost supplied for parent
+        String parentWithCost = " " + PREFIX_TYPE + "p"
+                + " " + PREFIX_NAME + "Grace Lee"
+                + " " + PREFIX_PHONE + "95551234"
+                + " " + PREFIX_EMAIL + "grace.lee@example.com"
+                + " " + PREFIX_ADDRESS + "88 Sunset Avenue"
+                + PAY_DESC_AMY;
+        assertParseFailure(parser, parentWithCost, AddCommand.MESSAGE_PARENT_COST_IMMUTABLE);
+
         // invalid address
         assertParseFailure(parser, TYPE_DESC_BOB + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + INVALID_ADDRESS_DESC


### PR DESCRIPTION
Previously, parent cost was displayed instead of triggering: Cannot add cost for a parent. Parent cost is derived from their linked children.